### PR TITLE
Use `numpy.prod` instead on `numpy.product`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, numpy_prod ]
   pull_request:
     branches: [ master ]
 
@@ -30,6 +30,7 @@ jobs:
         python -m pip install flake8 pytest
         python -m pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip list
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master, numpy_prod ]
+    branches: [ master, issue60 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, issue60 ]
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master, issue60 ]
   pull_request:
-    branches: [ master, issue60 ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/pyfive/dataobjects.py
+++ b/pyfive/dataobjects.py
@@ -187,7 +187,7 @@ class DataObjects(object):
 
         # read in the dataspace information
         shape, maxshape = determine_data_shape(self.msg_data, offset)
-        items = int(np.product(shape))
+        items = int(np.prod(shape))
         offset += _padded_size(attr_dict['dataspace_size'], padding_multiple)
 
         # read in the value(s)


### PR DESCRIPTION
...and adding a conda list in the GH workflow to see what deps we are pulling in. Numpy's new API is `np.prod` https://numpy.org/doc/stable/reference/generated/numpy.prod.html and the child PyActive branch is failing becuase of this https://github.com/valeriupredoi/PyActiveStorage/pull/189